### PR TITLE
upgrade to yaml_serde 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,12 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
 name = "format_serde_error"
 version = "0.3.0"
 dependencies = [
@@ -76,6 +76,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,10 +91,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "lazy_static"
@@ -101,12 +123,6 @@ name = "libc"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "output_vt100"
@@ -131,11 +147,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -155,18 +171,18 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -179,32 +195,33 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
 dependencies = [
- "dtoa",
- "linked-hash-map",
+ "indexmap",
+ "itoa 1.0.5",
+ "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -217,16 +234,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unsafe-libyaml"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "winapi"
@@ -249,12 +272,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ graphemes_support = ["unicode-segmentation"]
 colored = { version = "2", optional = true }
 serde_json = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }
-serde_yaml = { version = "0.8", optional = true }
+serde_yaml = { version = "0.9", optional = true }
 unicode-segmentation = { version = "1", optional = true }
 toml = { version = "0.5", optional = true }
 

--- a/examples/toml.rs
+++ b/examples/toml.rs
@@ -2,6 +2,7 @@ use format_serde_error::SerdeError;
 
 #[derive(Debug, serde::Deserialize)]
 struct Config {
+    #[allow(dead_code)]
     values: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,11 +120,7 @@ use colored::Colorize;
 
 use std::{
     fmt,
-    sync::atomic::{
-        AtomicBool,
-        AtomicUsize,
-        Ordering,
-    },
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 #[cfg(feature = "colored")]
@@ -134,13 +130,7 @@ mod control;
 mod test;
 
 #[cfg(feature = "colored")]
-pub use control::{
-    always_color,
-    never_color,
-    set_coloring_mode,
-    use_environment,
-    ColoringMode,
-};
+pub use control::{always_color, never_color, set_coloring_mode, use_environment, ColoringMode};
 
 /// If the output should be contextualized or not.
 pub const CONTEXTUALIZE_DEFAULT: bool = true;

--- a/src/test/config.rs
+++ b/src/test/config.rs
@@ -1,7 +1,4 @@
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,8 +1,5 @@
 #[cfg(feature = "colored")]
-use colored::{
-    ColoredString,
-    Colorize,
-};
+use colored::{ColoredString, Colorize};
 
 mod config;
 
@@ -32,10 +29,7 @@ mod toml {
     use colored::Colorize;
     use pretty_assertions::assert_eq;
 
-    use super::{
-        Config,
-        SerdeError,
-    };
+    use super::{Config, SerdeError};
 
     fn run_toml(config_str: &str) -> Result<String, anyhow::Error> {
         match toml::from_str::<Config>(config_str) {
@@ -110,10 +104,7 @@ mod yaml {
     use colored::Colorize;
     use pretty_assertions::assert_eq;
 
-    use super::{
-        Config,
-        SerdeError,
-    };
+    use super::{Config, SerdeError};
 
     fn run_yaml(config_str: &str) -> Result<String, anyhow::Error> {
         match serde_yaml::from_str::<Config>(config_str) {
@@ -127,7 +118,7 @@ mod yaml {
         super::init();
 
         let input = "";
-        let expected = format!("{}\n", "EOF while parsing a value".red().bold());
+        let expected = format!("{}\n", "missing field `values`".red().bold());
         let got = run_yaml(input)?;
 
         print!("expected:{}", expected);
@@ -161,7 +152,7 @@ mod yaml {
         expected.push_str(&format!(
             "    {}{}\n",
             separator,
-            "         ^ values[112]: invalid type: map, expected a string at line 114 column 12"
+            "  ^ values[112]: invalid type: map, expected a string at line 114 column 5"
                 .red()
                 .bold()
         ));
@@ -188,10 +179,7 @@ mod json {
     use colored::Colorize;
     use pretty_assertions::assert_eq;
 
-    use super::{
-        Config,
-        SerdeError,
-    };
+    use super::{Config, SerdeError};
 
     fn run_json(config_str: &str) -> Result<String, anyhow::Error> {
         match serde_json::from_str::<Config>(config_str) {


### PR DESCRIPTION
This updates the yaml_serde to the latest 0.9 to make it compatible with newer
code and fixes some tests as the error output has slightly changed.